### PR TITLE
Safe encode values with = in them

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -145,7 +145,7 @@ function isQuoted (val) {
 
 function safe (val) {
   return ( typeof val !== "string"
-         || val.match(/[\r\n]/)
+         || val.match(/[=\r\n]/)
          || val.match(/^\[/)
          || (val.length > 1
              && isQuoted(val))

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -29,6 +29,8 @@ ar   = this is included
 br = cold
 br = warm
 
+eq = "eq=eq"
+
 ; a section
 [a]
 av = a val

--- a/test/foo.js
+++ b/test/foo.js
@@ -18,6 +18,7 @@ var i = require("../")
             + 'ar[]=three\n'
             + 'ar[]=this is included\n'
             + 'br=warm\n'
+            + 'eq=\"eq=eq\"\n'
             + '\n'
             + '[a]\n'
             + 'av=a val\n'
@@ -43,6 +44,7 @@ var i = require("../")
       'zr': ['deedee'],
       'ar': ['one', 'three', 'this is included'],
       'br': 'warm',
+      'eq': 'eq=eq',
       a:
        { av: 'a val',
          e: '{ o: p, a: { av: a val, b: { c: { e: "this [value]" } } } }',


### PR DESCRIPTION
If a value contains a =, it will not wrap the value with quotes. This causes issues with other INI Parsers such as PHP.

Change safe to also quote values with = in them.